### PR TITLE
Potential fix for code scanning alert no. 1: Unread local variable

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -117,7 +117,7 @@ public class App {
                     String query = "//users/user[login/text()='" + username + 
                                    "' and pass/text()='" + password + "']" +
                                    "/secret/text()";
-                    String secret = (String)xPath.evaluate(query, inputXml, XPathConstants.STRING);
+                    xPath.evaluate(query, inputXml, XPathConstants.STRING);
                 }
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Drapsague/Test_Java_vuln/security/code-scanning/1](https://github.com/Drapsague/Test_Java_vuln/security/code-scanning/1)

To resolve this issue, the unused variable `secret` should be removed from the code. The assignment operation involving `xPath.evaluate()` can remain intact if its result is directly discarded or if it is used in some way. Alternatively, if the result of the operation is unnecessary, the operation itself can be removed.

In this case, the best fix is to delete the declaration and assignment of `secret` unless further functionality is planned for it. If the `xPath.evaluate()` call is not needed, it can also be removed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
